### PR TITLE
fix: Automatische Schema-Erkennung für v1 & v2 in GitHub Actions hinz…

### DIFF
--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -1,4 +1,5 @@
 name: Schema Validation
+
 on:
   pull_request:  # 🚨 Blockiert PRs bei Fehlern!
     paths:


### PR DESCRIPTION
…ugefügt

- Validierungsskript erkennt nun automatisch `schema_version` in Rezepten
- Lädt das passende Schema (`recipe-schema-v1.yaml` oder `recipe-schema-v2.yaml`)
- Blockiert PRs, falls das Schema nicht existiert oder das Rezept ungültig ist
- Verbesserte Debugging-Logs für einfachere Fehlersuche